### PR TITLE
Generalize database accessor.

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -31,7 +31,7 @@ func TestDatabase(t *testing.T) {
 	// All sub-tests to run.
 	tests := map[string]func(*testing.T){
 		"testInsertFeeAddress":          testInsertFeeAddress,
-		"testGetFeeAddressByTicketHash": testGetFeeAddressByTicketHash,
+		"testGetTicketByHash":           testGetTicketByHash,
 		"testGetFeesByFeeAddress":       testGetFeesByFeeAddress,
 		"testInsertFeeAddressVotingKey": testInsertFeeAddressVotingKey,
 		"testGetInactiveFeeAddresses":   testGetInactiveFeeAddresses,
@@ -72,7 +72,7 @@ func testInsertFeeAddress(t *testing.T) {
 	}
 }
 
-func testGetFeeAddressByTicketHash(t *testing.T) {
+func testGetTicketByHash(t *testing.T) {
 	// Insert a ticket into the database.
 	err := db.InsertFeeAddress(ticket)
 	if err != nil {
@@ -80,7 +80,7 @@ func testGetFeeAddressByTicketHash(t *testing.T) {
 	}
 
 	// Retrieve ticket from database.
-	retrieved, err := db.GetFeeAddressByTicketHash(ticket.Hash)
+	retrieved, err := db.GetTicketByHash(ticket.Hash)
 	if err != nil {
 		t.Fatalf("error retrieving ticket by ticket hash: %v", err)
 	}
@@ -99,7 +99,7 @@ func testGetFeeAddressByTicketHash(t *testing.T) {
 	}
 
 	// Error if non-existent ticket requested.
-	_, err = db.GetFeeAddressByTicketHash("Not a real ticket hash")
+	_, err = db.GetTicketByHash("Not a real ticket hash")
 	if err == nil {
 		t.Fatal("expected an error while retrieving a non-existent ticket")
 	}
@@ -159,7 +159,7 @@ func testInsertFeeAddressVotingKey(t *testing.T) {
 	}
 
 	// Retrieve ticket from database.
-	retrieved, err := db.GetFeeAddressByTicketHash(ticket.Hash)
+	retrieved, err := db.GetTicketByHash(ticket.Hash)
 	if err != nil {
 		t.Fatalf("error retrieving ticket by ticket hash: %v", err)
 	}

--- a/webapi/methods.go
+++ b/webapi/methods.go
@@ -88,7 +88,7 @@ func feeAddress(c *gin.Context) {
 
 	/*
 		// TODO - DB - deal with cached responses
-		ticket, err := db.GetFeeAddressByTicketHash(ticketHashStr)
+		ticket, err := db.GetTicketByHash(ticketHashStr)
 		if err != nil && !errors.Is(err, database.ErrNoTicketFound) {
 			c.AbortWithError(http.StatusInternalServerError, errors.New("database error"))
 			return
@@ -416,7 +416,7 @@ func setVoteBits(c *gin.Context) {
 		return
 	}
 
-	addr, err := db.GetCommitmentAddressByTicketHash(txHash.String())
+	ticket, err := db.GetTicketByHash(txHash.String())
 	if err != nil {
 		c.AbortWithError(http.StatusBadRequest, errors.New("invalid ticket"))
 		return
@@ -424,7 +424,7 @@ func setVoteBits(c *gin.Context) {
 
 	// verify message
 	message := fmt.Sprintf("vsp v3 setvotebits %d %s %d", setVoteBitsRequest.Timestamp, txHash, voteBits)
-	err = dcrutil.VerifyMessage(addr, signature, message, cfg.NetParams)
+	err = dcrutil.VerifyMessage(ticket.CommitmentAddress, signature, message, cfg.NetParams)
 	if err != nil {
 		c.AbortWithError(http.StatusBadRequest, errors.New("message did not pass verification"))
 		return
@@ -470,7 +470,7 @@ func ticketStatus(c *gin.Context) {
 		return
 	}
 
-	addr, err := db.GetCommitmentAddressByTicketHash(ticketHashStr)
+	ticket, err := db.GetTicketByHash(ticketHashStr)
 	if err != nil {
 		c.AbortWithError(http.StatusBadRequest, errors.New("invalid ticket"))
 		return
@@ -478,7 +478,7 @@ func ticketStatus(c *gin.Context) {
 
 	// verify message
 	message := fmt.Sprintf("vsp v3 ticketstatus %d %s", ticketStatusRequest.Timestamp, ticketHashStr)
-	err = dcrutil.VerifyMessage(addr, signature, message, cfg.NetParams)
+	err = dcrutil.VerifyMessage(ticket.CommitmentAddress, signature, message, cfg.NetParams)
 	if err != nil {
 		c.AbortWithError(http.StatusBadRequest, errors.New("invalid signature"))
 		return


### PR DESCRIPTION
One database accessor to lookup tickets by hash should be enough.

### Note

Renaming this function does mean that the database API will differ slightly between dcrvsp and dcrstakepool, however the behaviour remains the same.