### PR TITLE
Error logging for API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 ## Design decisions
 
 - [gin-gonic](https://github.com/gin-gonic/gin) webserver for both front-end and API.
-  - API uses JSON encoded reqs/resps in HTTP body.
+  - Success responses use HTTP status 200 and a JSON encoded body.
+  - Error responses use either HTTP status 500 or 400, and a JSON encoded error in the body (eg. `{"error":"Description"}')
 - [bbolt](https://github.com/etcd-io/bbolt) k/v database.
   - Tickets are stored in a single bucket, using ticket hash as the key and a
     json encoded representation of the ticket as the value.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
 - Accountability for both client and server changes to voting preferences.
 - Consistency checking across connected wallets.
 
+## Notes
+
+- dcrd must have transaction index enabled so `getrawtransaction` can be used.
+
 ## Issue Tracker
 
 The [integrated github issue tracker](https://github.com/jholdstock/dcrvsp/issues)

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -9,7 +9,11 @@ import (
 
 var (
 	testDb = "test.db"
-	ticket = Ticket{
+	db     *VspDatabase
+)
+
+func exampleTicket() Ticket {
+	return Ticket{
 		Hash:                "Hash",
 		CommitmentAddress:   "Address",
 		CommitmentSignature: "CommitmentSignature",
@@ -20,8 +24,7 @@ var (
 		VotingKey:           "VotingKey",
 		Expiration:          4,
 	}
-	db *VspDatabase
-)
+}
 
 // TestDatabase runs all database tests.
 func TestDatabase(t *testing.T) {
@@ -60,6 +63,7 @@ func TestDatabase(t *testing.T) {
 
 func testInsertFeeAddress(t *testing.T) {
 	// Insert a ticket into the database.
+	ticket := exampleTicket()
 	err := db.InsertFeeAddress(ticket)
 	if err != nil {
 		t.Fatalf("error storing ticket in database: %v", err)
@@ -70,9 +74,17 @@ func testInsertFeeAddress(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error inserting ticket with duplicate hash")
 	}
+
+	// Inserting a ticket with empty hash should fail.
+	ticket.Hash = ""
+	err = db.InsertFeeAddress(ticket)
+	if err == nil {
+		t.Fatal("expected an error inserting ticket with no hash")
+	}
 }
 
 func testGetTicketByHash(t *testing.T) {
+	ticket := exampleTicket()
 	// Insert a ticket into the database.
 	err := db.InsertFeeAddress(ticket)
 	if err != nil {
@@ -107,6 +119,7 @@ func testGetTicketByHash(t *testing.T) {
 
 func testGetFeesByFeeAddress(t *testing.T) {
 	// Insert a ticket into the database.
+	ticket := exampleTicket()
 	err := db.InsertFeeAddress(ticket)
 	if err != nil {
 		t.Fatalf("error storing ticket in database: %v", err)
@@ -145,6 +158,7 @@ func testGetFeesByFeeAddress(t *testing.T) {
 
 func testInsertFeeAddressVotingKey(t *testing.T) {
 	// Insert a ticket into the database.
+	ticket := exampleTicket()
 	err := db.InsertFeeAddress(ticket)
 	if err != nil {
 		t.Fatalf("error storing ticket in database: %v", err)
@@ -173,6 +187,7 @@ func testInsertFeeAddressVotingKey(t *testing.T) {
 
 func testGetInactiveFeeAddresses(t *testing.T) {
 	// Insert a ticket into the database.
+	ticket := exampleTicket()
 	err := db.InsertFeeAddress(ticket)
 	if err != nil {
 		t.Fatalf("error storing ticket in database: %v", err)

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -25,10 +25,11 @@ var (
 )
 
 func (vdb *VspDatabase) InsertFeeAddress(ticket Ticket) error {
+	hashBytes := []byte(ticket.Hash)
 	return vdb.db.Update(func(tx *bolt.Tx) error {
 		ticketBkt := tx.Bucket(vspBktK).Bucket(ticketBktK)
 
-		if ticketBkt.Get([]byte(ticket.Hash)) != nil {
+		if ticketBkt.Get(hashBytes) != nil {
 			return fmt.Errorf("ticket already exists with hash %s", ticket.Hash)
 		}
 
@@ -37,7 +38,7 @@ func (vdb *VspDatabase) InsertFeeAddress(ticket Ticket) error {
 			return err
 		}
 
-		return ticketBkt.Put([]byte(ticket.Hash), ticketBytes)
+		return ticketBkt.Put(hashBytes, ticketBytes)
 	})
 }
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -30,5 +30,6 @@ golangci-lint run --disable-all --deadline=10m \
   --enable=unparam \
   --enable=deadcode \
   --enable=unused \
+  --enable=errcheck \
   --enable=asciicheck
-#  --enable=errcheck \
+  

--- a/webapi/methods.go
+++ b/webapi/methods.go
@@ -118,7 +118,7 @@ func feeAddress(c *gin.Context) {
 	}
 
 	var resp dcrdtypes.TxRawResult
-	err = walletClient.Call(ctx, "getrawtransaction", &resp, txHash.String(), true)
+	err = walletClient.Call(ctx, "getrawtransaction", &resp, txHash.String(), 1)
 	if err != nil {
 		c.AbortWithError(http.StatusBadRequest, errors.New("unknown transaction"))
 		return
@@ -199,7 +199,6 @@ func feeAddress(c *gin.Context) {
 		// VotingKey: set during payfee
 	}
 
-	// TODO: Insert into DB
 	err = db.InsertFeeAddress(dbTicket)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, errors.New("database error"))

--- a/webapi/responses.go
+++ b/webapi/responses.go
@@ -1,64 +1,64 @@
 package webapi
 
 type pubKeyResponse struct {
-	Timestamp int64  `json:"timestamp"`
-	PubKey    []byte `json:"pubKey"`
+	Timestamp int64  `json:"timestamp" binding:"required"`
+	PubKey    []byte `json:"pubKey" binding:"required"`
 }
 
 type feeResponse struct {
-	Timestamp int64   `json:"timestamp"`
-	Fee       float64 `json:"fee"`
+	Timestamp int64   `json:"timestamp" binding:"required"`
+	Fee       float64 `json:"fee" binding:"required"`
 }
 
 type FeeAddressRequest struct {
-	Timestamp  int64  `json:"timestamp"`
-	TicketHash string `json:"ticketHash"`
-	Signature  string `json:"signature"`
+	Timestamp  int64  `json:"timestamp" binding:"required"`
+	TicketHash string `json:"ticketHash" binding:"required"`
+	Signature  string `json:"signature" binding:"required"`
 }
 
 type feeAddressResponse struct {
-	Timestamp  int64             `json:"timestamp"`
-	FeeAddress string            `json:"feeAddress"`
-	Fee        float64           `json:"fee"`
-	Expiration int64             `json:"expiration"`
-	Request    FeeAddressRequest `json:"request"`
+	Timestamp  int64             `json:"timestamp" binding:"required"`
+	FeeAddress string            `json:"feeAddress" binding:"required"`
+	Fee        float64           `json:"fee" binding:"required"`
+	Expiration int64             `json:"expiration" binding:"required"`
+	Request    FeeAddressRequest `json:"request" binding:"required"`
 }
 
 type PayFeeRequest struct {
-	Timestamp int64  `json:"timestamp"`
-	Hex       []byte `json:"feeTx"`
-	VotingKey string `json:"votingKey"`
-	VoteBits  uint16 `json:"voteBits"`
+	Timestamp int64  `json:"timestamp" binding:"required"`
+	Hex       []byte `json:"feeTx" binding:"required"`
+	VotingKey string `json:"votingKey" binding:"required"`
+	VoteBits  uint16 `json:"voteBits" binding:"required"`
 }
 
 type payFeeResponse struct {
-	Timestamp int64         `json:"timestamp"`
-	TxHash    string        `json:"txHash"`
-	Request   PayFeeRequest `json:"request"`
+	Timestamp int64         `json:"timestamp" binding:"required"`
+	TxHash    string        `json:"txHash" binding:"required"`
+	Request   PayFeeRequest `json:"request" binding:"required"`
 }
 
 type SetVoteBitsRequest struct {
-	Timestamp  int64  `json:"timestamp"`
-	TicketHash string `json:"ticketHash"`
-	Signature  string `json:"commitmentSignature"`
-	VoteBits   uint16 `json:"voteBits"`
+	Timestamp  int64  `json:"timestamp" binding:"required"`
+	TicketHash string `json:"ticketHash" binding:"required"`
+	Signature  string `json:"commitmentSignature" binding:"required"`
+	VoteBits   uint16 `json:"voteBits" binding:"required"`
 }
 
 type setVoteBitsResponse struct {
-	Timestamp int64              `json:"timestamp"`
-	Request   SetVoteBitsRequest `json:"request"`
-	VoteBits  uint16             `json:"voteBits"`
+	Timestamp int64              `json:"timestamp" binding:"required"`
+	Request   SetVoteBitsRequest `json:"request" binding:"required"`
+	VoteBits  uint16             `json:"voteBits" binding:"required"`
 }
 
 type TicketStatusRequest struct {
-	Timestamp  int64  `json:"timestamp"`
-	TicketHash string `json:"ticketHash"`
-	Signature  string `json:"signature"`
+	Timestamp  int64  `json:"timestamp" binding:"required"`
+	TicketHash string `json:"ticketHash" binding:"required"`
+	Signature  string `json:"signature" binding:"required"`
 }
 
 type ticketStatusResponse struct {
-	Timestamp int64               `json:"timestamp"`
-	Request   TicketStatusRequest `json:"request"`
-	Status    string              `json:"status"`
-	VoteBits  uint16              `json:"votebits"`
+	Timestamp int64               `json:"timestamp" binding:"required"`
+	Request   TicketStatusRequest `json:"request" binding:"required"`
+	Status    string              `json:"status" binding:"required"`
+	VoteBits  uint16              `json:"votebits" binding:"required"`
 }

--- a/webapi/server.go
+++ b/webapi/server.go
@@ -27,7 +27,7 @@ var db *database.VspDatabase
 var walletRPC rpc.Client
 
 func Start(ctx context.Context, requestShutdownChan chan struct{}, shutdownWg *sync.WaitGroup,
-	listen string, db *database.VspDatabase, wRPC rpc.Client, releaseMode bool, config Config) error {
+	listen string, vdb *database.VspDatabase, wRPC rpc.Client, releaseMode bool, config Config) error {
 
 	// Create TCP listener.
 	var listenConfig net.ListenConfig
@@ -74,6 +74,7 @@ func Start(ctx context.Context, requestShutdownChan chan struct{}, shutdownWg *s
 	}()
 
 	cfg = config
+	db = vdb
 	walletRPC = wRPC
 
 	return nil


### PR DESCRIPTION
- Use gin for unmarshalling json
- Logging for every negative path in every API method. Bad requests are `WARN`, internal server errors are `ERROR`
- Removed explicit checks for `MaxHashStringSize` because this is already checked in `NewHashFromStr`
