### PR TITLE
Rework client/server authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ ticket details + fee to a VSP, and the VSP will take the fee and vote in return.
 
 - When dcrvsp is started for the first time, it generates a ed25519 keypair and
   stores it in the database. This key is used to sign all API responses, and the
-  signature is included in the response header `VSP-Signature`. Error responses
+  signature is included in the response header `VSP-Server-Signature`. Error responses
   are not signed.
+- Every client request which references a ticket should include a HTTP header
+  `VSP-Client-Signature`. The value of this header must be a signature of the
+  request body, signed with the commitment address of the referenced ticket.
 - An xpub key is provided to dcrvsp via config. The first time dcrvsp starts, it
   imports this xpub to create a new wallet account. This account is used to
   derive addresses for fee payments.

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -15,17 +15,16 @@ var (
 
 func exampleTicket() Ticket {
 	return Ticket{
-		Hash:                "Hash",
-		CommitmentAddress:   "Address",
-		CommitmentSignature: "CommitmentSignature",
-		FeeAddress:          "FeeAddress",
-		SDiff:               1,
-		BlockHeight:         2,
-		VoteChoices:         map[string]string{"AgendaID": "Choice"},
-		VotingKey:           "VotingKey",
-		VSPFee:              0.1,
-		FeeExpiration:       4,
-		FeeTxHash:           "",
+		Hash:              "Hash",
+		CommitmentAddress: "Address",
+		FeeAddress:        "FeeAddress",
+		SDiff:             1,
+		BlockHeight:       2,
+		VoteChoices:       map[string]string{"AgendaID": "Choice"},
+		VotingKey:         "VotingKey",
+		VSPFee:            0.1,
+		FeeExpiration:     4,
+		FeeTxHash:         "",
 	}
 }
 
@@ -95,15 +94,17 @@ func testGetTicketByHash(t *testing.T) {
 	}
 
 	// Retrieve ticket from database.
-	retrieved, err := db.GetTicketByHash(ticket.Hash)
+	retrieved, found, err := db.GetTicketByHash(ticket.Hash)
 	if err != nil {
 		t.Fatalf("error retrieving ticket by ticket hash: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found==true")
 	}
 
 	// Check ticket fields match expected.
 	if retrieved.Hash != ticket.Hash ||
 		retrieved.CommitmentAddress != ticket.CommitmentAddress ||
-		retrieved.CommitmentSignature != ticket.CommitmentSignature ||
 		retrieved.FeeAddress != ticket.FeeAddress ||
 		retrieved.SDiff != ticket.SDiff ||
 		retrieved.BlockHeight != ticket.BlockHeight ||
@@ -115,10 +116,13 @@ func testGetTicketByHash(t *testing.T) {
 		t.Fatal("retrieved ticket value didnt match expected")
 	}
 
-	// Error if non-existent ticket requested.
-	_, err = db.GetTicketByHash("Not a real ticket hash")
-	if err == nil {
-		t.Fatal("expected an error while retrieving a non-existent ticket")
+	// Check found==false when requesting a non-existent ticket.
+	_, found, err = db.GetTicketByHash("Not a real ticket hash")
+	if err != nil {
+		t.Fatalf("error retrieving ticket by ticket hash: %v", err)
+	}
+	if found {
+		t.Fatal("expected found==false")
 	}
 }
 
@@ -141,7 +145,7 @@ func testSetTicketVotingKey(t *testing.T) {
 	}
 
 	// Retrieve ticket from database.
-	retrieved, err := db.GetTicketByHash(ticket.Hash)
+	retrieved, _, err := db.GetTicketByHash(ticket.Hash)
 	if err != nil {
 		t.Fatalf("error retrieving ticket by ticket hash: %v", err)
 	}
@@ -171,7 +175,7 @@ func testUpdateExpireAndFee(t *testing.T) {
 	}
 
 	// Get updated ticket
-	retrieved, err := db.GetTicketByHash(ticket.Hash)
+	retrieved, _, err := db.GetTicketByHash(ticket.Hash)
 	if err != nil {
 		t.Fatalf("error retrieving updated ticket: %v", err)
 	}
@@ -199,7 +203,7 @@ func testUpdateVoteChoices(t *testing.T) {
 	}
 
 	// Get updated ticket
-	retrieved, err := db.GetTicketByHash(ticket.Hash)
+	retrieved, _, err := db.GetTicketByHash(ticket.Hash)
 	if err != nil {
 		t.Fatalf("error retrieving updated ticket: %v", err)
 	}

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/blockchain/stake/v3"
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -17,68 +16,22 @@ import (
 // feeAddress is the handler for "POST /feeaddress".
 func feeAddress(c *gin.Context) {
 
-	ctx := c.Request.Context()
-
-	reqBytes, err := c.GetRawData()
-	if err != nil {
-		log.Warnf("Error reading request from %s: %v", c.ClientIP(), err)
-		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
-		return
-	}
+	// Get values which have been added to context by middleware.
+	rawRequest := c.MustGet("RawRequest").([]byte)
+	ticket := c.MustGet("Ticket").(database.Ticket)
+	knownTicket := c.MustGet("KnownTicket").(bool)
+	commitmentAddress := c.MustGet("CommitmentAddress").(string)
+	fWalletClient := c.MustGet("FeeWalletClient").(*rpc.FeeWalletRPC)
 
 	var feeAddressRequest FeeAddressRequest
-	if err := binding.JSON.BindBody(reqBytes, &feeAddressRequest); err != nil {
+	if err := binding.JSON.BindBody(rawRequest, &feeAddressRequest); err != nil {
 		log.Warnf("Bad feeaddress request from %s: %v", c.ClientIP(), err)
 		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
 		return
 	}
 
-	// Create a fee wallet client.
-	fWalletConn, err := feeWalletConnect()
-	if err != nil {
-		log.Errorf("Fee wallet connection error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-	fWalletClient, err := rpc.FeeWalletClient(ctx, fWalletConn)
-	if err != nil {
-		log.Errorf("Fee wallet client error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// Check if this ticket already appears in the database.
-	ticket, ticketFound, err := db.GetTicketByHash(feeAddressRequest.TicketHash)
-	if err != nil {
-		log.Errorf("GetTicketByHash error: %v", err)
-		sendErrorResponse("database error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// If the ticket was found in the database we already know its commitment
-	// address. Otherwise we need to get it from the chain.
-	var commitmentAddress string
-	if ticketFound {
-		commitmentAddress = ticket.CommitmentAddress
-	} else {
-		commitmentAddress, err = fWalletClient.GetTicketCommitmentAddress(feeAddressRequest.TicketHash, cfg.NetParams)
-		if err != nil {
-			log.Errorf("GetTicketCommitmentAddress error: %v", err)
-			sendErrorResponse("database error", http.StatusInternalServerError, c)
-			return
-		}
-	}
-
-	// Validate request signature to ensure ticket ownership.
-	err = validateSignature(reqBytes, commitmentAddress, c)
-	if err != nil {
-		log.Warnf("Bad signature from %s: %v", c.ClientIP(), err)
-		sendErrorResponse("bad signature", http.StatusBadRequest, c)
-		return
-	}
-
-	// VSP already knows this ticket, and has already issued it a fee address.
-	if ticketFound {
+	// VSP already knows this ticket and has already issued it a fee address.
+	if knownTicket {
 		// If the expiry period has passed we need to issue a new fee.
 		now := time.Now()
 		expire := ticket.FeeExpiration
@@ -87,7 +40,7 @@ func feeAddress(c *gin.Context) {
 			expire = now.Add(cfg.FeeAddressExpiration).Unix()
 			VSPFee = cfg.VSPFee
 
-			err = db.UpdateExpireAndFee(ticket.Hash, expire, VSPFee)
+			err := db.UpdateExpireAndFee(ticket.Hash, expire, VSPFee)
 			if err != nil {
 				log.Errorf("UpdateExpireAndFee error: %v", err)
 				sendErrorResponse("database error", http.StatusInternalServerError, c)
@@ -108,17 +61,12 @@ func feeAddress(c *gin.Context) {
 	// Beyond this point we are processing a new ticket which the VSP has not
 	// seen before.
 
-	txHash, err := chainhash.NewHashFromStr(feeAddressRequest.TicketHash)
-	if err != nil {
-		log.Warnf("Invalid ticket hash from %s", c.ClientIP())
-		sendErrorResponse("invalid ticket hash", http.StatusBadRequest, c)
-		return
-	}
+	ticketHash := feeAddressRequest.TicketHash
 
 	// Ensure ticket exists and is mined.
-	resp, err := fWalletClient.GetRawTransaction(txHash.String())
+	resp, err := fWalletClient.GetRawTransaction(ticketHash)
 	if err != nil {
-		log.Warnf("Could not retrieve tx %s for %s: %v", txHash, c.ClientIP(), err)
+		log.Warnf("Could not retrieve tx %s for %s: %v", ticketHash, c.ClientIP(), err)
 		sendErrorResponse("unknown transaction", http.StatusBadRequest, c)
 		return
 	}
@@ -179,7 +127,7 @@ func feeAddress(c *gin.Context) {
 	expire := now.Add(cfg.FeeAddressExpiration).Unix()
 
 	dbTicket := database.Ticket{
-		Hash:              txHash.String(),
+		Hash:              ticketHash,
 		CommitmentAddress: commitmentAddress,
 		FeeAddress:        newAddress,
 		SDiff:             blockHeader.SBits,

--- a/webapi/helpers.go
+++ b/webapi/helpers.go
@@ -1,9 +1,12 @@
 package webapi
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/gin-gonic/gin"
 )
 
 func currentVoteVersion(params *chaincfg.Params) uint32 {
@@ -39,5 +42,19 @@ agendaLoop:
 		return fmt.Errorf("agenda %q not found for vote version %d", agenda, voteVersion)
 	}
 
+	return nil
+}
+
+func validateSignature(reqBytes []byte, commitmentAddress string, c *gin.Context) error {
+	// Ensure a signature is provided.
+	signature := c.GetHeader("VSP-Client-Signature")
+	if signature == "" {
+		return errors.New("no VSP-Client-Signature header")
+	}
+
+	err := dcrutil.VerifyMessage(commitmentAddress, signature, string(reqBytes), cfg.NetParams)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -1,0 +1,124 @@
+package webapi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/jholdstock/dcrvsp/rpc"
+)
+
+type ticketHashRequest struct {
+	TicketHash string `json:"tickethash" binding:"required"`
+}
+
+// withFeeWalletClient middleware adds a fee wallet client to the request
+// context for downstream handlers to make use of.
+func withFeeWalletClient() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		fWalletConn, err := feeWalletConnect()
+		if err != nil {
+			log.Errorf("Fee wallet connection error: %v", err)
+			sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
+			return
+		}
+		fWalletClient, err := rpc.FeeWalletClient(c, fWalletConn)
+		if err != nil {
+			log.Errorf("Fee wallet client error: %v", err)
+			sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
+			return
+		}
+
+		c.Set("FeeWalletClient", fWalletClient)
+	}
+}
+
+// withVotingWalletClient middleware adds a voting wallet client to the request
+// context for downstream handlers to make use of.
+func withVotingWalletClient() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		vWalletConn, err := votingWalletConnect()
+		if err != nil {
+			log.Errorf("Voting wallet connection error: %v", err)
+			sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
+			return
+		}
+		vWalletClient, err := rpc.VotingWalletClient(c, vWalletConn)
+		if err != nil {
+			log.Errorf("Voting wallet client error: %v", err)
+			sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
+			return
+		}
+
+		c.Set("VotingWalletClient", vWalletClient)
+	}
+}
+
+// vspAuth middleware reads the request body and extracts the ticket hash. The
+// commitment address for the ticket is retrieved from the database if it is
+// known, or it is retrieved from the chain if not.
+// The middleware errors out if the VSP-Client-Signature header of the request
+// does not contain the request body signed with the commitment address.
+// Ticket information is added to the request context for downstream handlers to
+// use.
+func vspAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Read request bytes.
+		reqBytes, err := c.GetRawData()
+		if err != nil {
+			log.Warnf("Error reading request from %s: %v", c.ClientIP(), err)
+			sendErrorResponse(err.Error(), http.StatusBadRequest, c)
+			return
+		}
+
+		// Add raw request to context for downstream handlers to use.
+		c.Set("RawRequest", reqBytes)
+
+		// Parse request and ensure there is a ticket hash included.
+		var request ticketHashRequest
+		if err := binding.JSON.BindBody(reqBytes, &request); err != nil {
+			log.Warnf("Bad request from %s: %v", c.ClientIP(), err)
+			sendErrorResponse(err.Error(), http.StatusBadRequest, c)
+			return
+		}
+		hash := request.TicketHash
+
+		// Check if this ticket already appears in the database.
+		ticket, ticketFound, err := db.GetTicketByHash(hash)
+		if err != nil {
+			log.Errorf("GetTicketByHash error: %v", err)
+			sendErrorResponse("database error", http.StatusInternalServerError, c)
+			return
+		}
+
+		// If the ticket was found in the database we already know its commitment
+		// address. Otherwise we need to get it from the chain.
+		var commitmentAddress string
+		if ticketFound {
+			commitmentAddress = ticket.CommitmentAddress
+		} else {
+			fWalletClient := c.MustGet("FeeWalletClient").(*rpc.FeeWalletRPC)
+			commitmentAddress, err = fWalletClient.GetTicketCommitmentAddress(hash, cfg.NetParams)
+			if err != nil {
+				log.Errorf("GetTicketCommitmentAddress error: %v", err)
+				sendErrorResponse("database error", http.StatusInternalServerError, c)
+				return
+			}
+		}
+
+		// Validate request signature to ensure ticket ownership.
+		err = validateSignature(reqBytes, commitmentAddress, c)
+		if err != nil {
+			log.Warnf("Bad signature from %s: %v", c.ClientIP(), err)
+			sendErrorResponse("bad signature", http.StatusBadRequest, c)
+			return
+		}
+
+		// Add ticket information to context so downstream handlers don't need
+		// to access the db for it.
+		c.Set("Ticket", ticket)
+		c.Set("KnownTicket", ticketFound)
+		c.Set("CommitmentAddress", commitmentAddress)
+	}
+
+}

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -13,78 +13,41 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
+	"github.com/jholdstock/dcrvsp/database"
 	"github.com/jholdstock/dcrvsp/rpc"
 )
 
 // payFee is the handler for "POST /payfee".
 func payFee(c *gin.Context) {
 
-	ctx := c.Request.Context()
+	// Get values which have been added to context by middleware.
+	rawRequest := c.MustGet("RawRequest").([]byte)
+	ticket := c.MustGet("Ticket").(database.Ticket)
+	knownTicket := c.MustGet("KnownTicket").(bool)
+	fWalletClient := c.MustGet("FeeWalletClient").(*rpc.FeeWalletRPC)
+	vWalletClient := c.MustGet("VotingWalletClient").(*rpc.VotingWalletRPC)
 
-	reqBytes, err := c.GetRawData()
-	if err != nil {
-		log.Warnf("Error reading request from %s: %v", c.ClientIP(), err)
-		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
+	if !knownTicket {
+		log.Warnf("Invalid ticket from %s", c.ClientIP())
+		sendErrorResponse("invalid ticket", http.StatusBadRequest, c)
 		return
 	}
 
 	var payFeeRequest PayFeeRequest
-	if err := binding.JSON.BindBody(reqBytes, &payFeeRequest); err != nil {
+	if err := binding.JSON.BindBody(rawRequest, &payFeeRequest); err != nil {
 		log.Warnf("Bad payfee request from %s: %v", c.ClientIP(), err)
 		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
 		return
 	}
 
-	// Create a fee wallet client.
-	fWalletConn, err := feeWalletConnect()
-	if err != nil {
-		log.Errorf("Fee wallet connection error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-	fWalletClient, err := rpc.FeeWalletClient(ctx, fWalletConn)
-	if err != nil {
-		log.Errorf("Fee wallet client error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// Check if this ticket already appears in the database.
-	ticket, ticketFound, err := db.GetTicketByHash(payFeeRequest.TicketHash)
-	if err != nil {
-		log.Errorf("GetTicketByHash error: %v", err)
-		sendErrorResponse("database error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// If the ticket was found in the database we already know its commitment
-	// address. Otherwise we need to get it from the chain.
-	var commitmentAddress string
-	if ticketFound {
-		commitmentAddress = ticket.CommitmentAddress
-	} else {
-		commitmentAddress, err = fWalletClient.GetTicketCommitmentAddress(payFeeRequest.TicketHash, cfg.NetParams)
-		if err != nil {
-			log.Errorf("GetTicketCommitmentAddress error: %v", err)
-			sendErrorResponse("database error", http.StatusInternalServerError, c)
-			return
-		}
-	}
-
-	// Validate request signature to ensure ticket ownership.
-	err = validateSignature(reqBytes, commitmentAddress, c)
-	if err != nil {
-		log.Warnf("Bad signature from %s: %v", c.ClientIP(), err)
-		sendErrorResponse("bad signature", http.StatusBadRequest, c)
-		return
-	}
-
-	// TODO: Respond early if the fee tx has already been broadcast for this
-	// ticket. Maybe indicate status - mempool/awaiting confs/confirmed.
-
-	if !ticketFound {
-		log.Warnf("Invalid ticket from %s", c.ClientIP())
-		sendErrorResponse("invalid ticket", http.StatusBadRequest, c)
+	// Respond early if fee transaction has already been broadcast for this
+	// ticket.
+	if ticket.FeeTxHash != "" {
+		sendJSONResponse(payFeeResponse{
+			Timestamp: time.Now().Unix(),
+			TxHash:    ticket.FeeTxHash,
+			Request:   payFeeRequest,
+		}, c)
 		return
 	}
 
@@ -217,19 +180,6 @@ findAddress:
 	if err != nil {
 		log.Warnf("Could not retrieve tx %s for %s: %v", ticket.Hash, c.ClientIP(), err)
 		sendErrorResponse("unknown transaction", http.StatusBadRequest, c)
-		return
-	}
-
-	vWalletConn, err := votingWalletConnect()
-	if err != nil {
-		log.Errorf("Voting wallet connection error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-	vWalletClient, err := rpc.VotingWalletClient(ctx, vWalletConn)
-	if err != nil {
-		log.Errorf("Voting wallet client error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
 		return
 	}
 

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -6,97 +6,37 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
+	"github.com/jholdstock/dcrvsp/database"
 	"github.com/jholdstock/dcrvsp/rpc"
 )
 
 // setVoteChoices is the handler for "POST /setvotechoices".
 func setVoteChoices(c *gin.Context) {
 
-	ctx := c.Request.Context()
+	// Get values which have been added to context by middleware.
+	rawRequest := c.MustGet("RawRequest").([]byte)
+	ticket := c.MustGet("Ticket").(database.Ticket)
+	knownTicket := c.MustGet("KnownTicket").(bool)
+	vWalletClient := c.MustGet("VotingWalletClient").(*rpc.VotingWalletRPC)
 
-	reqBytes, err := c.GetRawData()
-	if err != nil {
-		log.Warnf("Error reading request from %s: %v", c.ClientIP(), err)
-		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
-		return
-	}
-
-	var setVoteChoicesRequest SetVoteChoicesRequest
-	if err := binding.JSON.BindBody(reqBytes, &setVoteChoicesRequest); err != nil {
-		log.Warnf("Bad setvotechoices request from %s: %v", c.ClientIP(), err)
-		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
-		return
-	}
-
-	// Create a fee wallet client.
-	fWalletConn, err := feeWalletConnect()
-	if err != nil {
-		log.Errorf("Fee wallet connection error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-	fWalletClient, err := rpc.FeeWalletClient(ctx, fWalletConn)
-	if err != nil {
-		log.Errorf("Fee wallet client error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// Check if this ticket already appears in the database.
-	ticket, ticketFound, err := db.GetTicketByHash(setVoteChoicesRequest.TicketHash)
-	if err != nil {
-		log.Errorf("GetTicketByHash error: %v", err)
-		sendErrorResponse("database error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// If the ticket was found in the database we already know its commitment
-	// address. Otherwise we need to get it from the chain.
-	var commitmentAddress string
-	if ticketFound {
-		commitmentAddress = ticket.CommitmentAddress
-	} else {
-		commitmentAddress, err = fWalletClient.GetTicketCommitmentAddress(setVoteChoicesRequest.TicketHash, cfg.NetParams)
-		if err != nil {
-			log.Errorf("GetTicketCommitmentAddress error: %v", err)
-			sendErrorResponse("database error", http.StatusInternalServerError, c)
-			return
-		}
-	}
-
-	// Validate request signature to ensure ticket ownership.
-	err = validateSignature(reqBytes, commitmentAddress, c)
-	if err != nil {
-		log.Warnf("Bad signature from %s: %v", c.ClientIP(), err)
-		sendErrorResponse("bad signature", http.StatusBadRequest, c)
-		return
-	}
-
-	if !ticketFound {
+	if !knownTicket {
 		log.Warnf("Invalid ticket from %s", c.ClientIP())
 		sendErrorResponse("invalid ticket", http.StatusBadRequest, c)
 		return
 	}
 
-	voteChoices := setVoteChoicesRequest.VoteChoices
-	err = isValidVoteChoices(cfg.NetParams, currentVoteVersion(cfg.NetParams), voteChoices)
-	if err != nil {
-		log.Warnf("Invalid votechoices from %s: %v", c.ClientIP(), err)
+	var setVoteChoicesRequest SetVoteChoicesRequest
+	if err := binding.JSON.BindBody(rawRequest, &setVoteChoicesRequest); err != nil {
+		log.Warnf("Bad setvotechoices request from %s: %v", c.ClientIP(), err)
 		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
 		return
 	}
 
-	vWalletConn, err := votingWalletConnect()
+	voteChoices := setVoteChoicesRequest.VoteChoices
+	err := isValidVoteChoices(cfg.NetParams, currentVoteVersion(cfg.NetParams), voteChoices)
 	if err != nil {
-		log.Errorf("Voting wallet connection error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-
-	vWalletClient, err := rpc.VotingWalletClient(ctx, vWalletConn)
-	if err != nil {
-		log.Errorf("Voting wallet client error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
+		log.Warnf("Invalid votechoices from %s: %v", c.ClientIP(), err)
+		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
 		return
 	}
 

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -6,82 +6,34 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-	"github.com/jholdstock/dcrvsp/rpc"
+	"github.com/jholdstock/dcrvsp/database"
 )
 
 // ticketStatus is the handler for "GET /ticketstatus".
 func ticketStatus(c *gin.Context) {
 
-	ctx := c.Request.Context()
+	// Get values which have been added to context by middleware.
+	rawRequest := c.MustGet("RawRequest").([]byte)
+	ticket := c.MustGet("Ticket").(database.Ticket)
+	knownTicket := c.MustGet("KnownTicket").(bool)
 
-	reqBytes, err := c.GetRawData()
-	if err != nil {
-		log.Warnf("Error reading request from %s: %v", c.ClientIP(), err)
-		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
+	if !knownTicket {
+		log.Warnf("Invalid ticket from %s", c.ClientIP())
+		sendErrorResponse("invalid ticket", http.StatusBadRequest, c)
 		return
 	}
 
 	var ticketStatusRequest TicketStatusRequest
-	if err := binding.JSON.BindBody(reqBytes, &ticketStatusRequest); err != nil {
+	if err := binding.JSON.BindBody(rawRequest, &ticketStatusRequest); err != nil {
 		log.Warnf("Bad ticketstatus request from %s: %v", c.ClientIP(), err)
 		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
-		return
-	}
-
-	// Create a fee wallet client.
-	fWalletConn, err := feeWalletConnect()
-	if err != nil {
-		log.Errorf("Fee wallet connection error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-	fWalletClient, err := rpc.FeeWalletClient(ctx, fWalletConn)
-	if err != nil {
-		log.Errorf("Fee wallet client error: %v", err)
-		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// Check if this ticket already appears in the database.
-	ticket, ticketFound, err := db.GetTicketByHash(ticketStatusRequest.TicketHash)
-	if err != nil {
-		log.Errorf("GetTicketByHash error: %v", err)
-		sendErrorResponse("database error", http.StatusInternalServerError, c)
-		return
-	}
-
-	// If the ticket was found in the database we already know its commitment
-	// address. Otherwise we need to get it from the chain.
-	var commitmentAddress string
-	if ticketFound {
-		commitmentAddress = ticket.CommitmentAddress
-	} else {
-		commitmentAddress, err = fWalletClient.GetTicketCommitmentAddress(ticketStatusRequest.TicketHash, cfg.NetParams)
-		if err != nil {
-			log.Errorf("GetTicketCommitmentAddress error: %v", err)
-			sendErrorResponse("database error", http.StatusInternalServerError, c)
-			return
-		}
-	}
-
-	// Validate request signature to ensure ticket ownership.
-	err = validateSignature(reqBytes, commitmentAddress, c)
-	if err != nil {
-		log.Warnf("Bad signature from %s: %v", c.ClientIP(), err)
-		sendErrorResponse("bad signature", http.StatusBadRequest, c)
-		return
-	}
-
-	if !ticketFound {
-		log.Warnf("Invalid ticket from %s", c.ClientIP())
-		sendErrorResponse("invalid ticket", http.StatusBadRequest, c)
 		return
 	}
 
 	sendJSONResponse(ticketStatusResponse{
 		Timestamp:   time.Now().Unix(),
 		Request:     ticketStatusRequest,
-		Status:      "active", // TODO - active, pending, expired (missed, revoked?)
+		Status:      "active",
 		VoteChoices: ticket.VoteChoices,
 	}, c)
 }

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -1,55 +1,80 @@
 package webapi
 
 import (
-	"encoding/base64"
-	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/jholdstock/dcrvsp/rpc"
 )
 
 // ticketStatus is the handler for "GET /ticketstatus".
 func ticketStatus(c *gin.Context) {
+
+	ctx := c.Request.Context()
+
+	reqBytes, err := c.GetRawData()
+	if err != nil {
+		log.Warnf("Error reading request from %s: %v", c.ClientIP(), err)
+		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
+		return
+	}
+
 	var ticketStatusRequest TicketStatusRequest
-	if err := c.ShouldBindJSON(&ticketStatusRequest); err != nil {
+	if err := binding.JSON.BindBody(reqBytes, &ticketStatusRequest); err != nil {
 		log.Warnf("Bad ticketstatus request from %s: %v", c.ClientIP(), err)
 		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
 		return
 	}
 
-	// Validate TicketHash.
-	ticketHashStr := ticketStatusRequest.TicketHash
-	_, err := chainhash.NewHashFromStr(ticketHashStr)
+	// Create a fee wallet client.
+	fWalletConn, err := feeWalletConnect()
 	if err != nil {
-		log.Warnf("Invalid ticket hash from %s", c.ClientIP())
-		sendErrorResponse("invalid ticket hash", http.StatusBadRequest, c)
+		log.Errorf("Fee wallet connection error: %v", err)
+		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
+		return
+	}
+	fWalletClient, err := rpc.FeeWalletClient(ctx, fWalletConn)
+	if err != nil {
+		log.Errorf("Fee wallet client error: %v", err)
+		sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
 		return
 	}
 
-	// Validate Signature - sanity check signature is in base64 encoding.
-	signature := ticketStatusRequest.Signature
-	if _, err = base64.StdEncoding.DecodeString(signature); err != nil {
-		log.Warnf("Invalid signature from %s: %v", c.ClientIP(), err)
-		sendErrorResponse("invalid signature", http.StatusBadRequest, c)
+	// Check if this ticket already appears in the database.
+	ticket, ticketFound, err := db.GetTicketByHash(ticketStatusRequest.TicketHash)
+	if err != nil {
+		log.Errorf("GetTicketByHash error: %v", err)
+		sendErrorResponse("database error", http.StatusInternalServerError, c)
 		return
 	}
 
-	ticket, err := db.GetTicketByHash(ticketHashStr)
+	// If the ticket was found in the database we already know its commitment
+	// address. Otherwise we need to get it from the chain.
+	var commitmentAddress string
+	if ticketFound {
+		commitmentAddress = ticket.CommitmentAddress
+	} else {
+		commitmentAddress, err = fWalletClient.GetTicketCommitmentAddress(ticketStatusRequest.TicketHash, cfg.NetParams)
+		if err != nil {
+			log.Errorf("GetTicketCommitmentAddress error: %v", err)
+			sendErrorResponse("database error", http.StatusInternalServerError, c)
+			return
+		}
+	}
+
+	// Validate request signature to ensure ticket ownership.
+	err = validateSignature(reqBytes, commitmentAddress, c)
 	if err != nil {
+		log.Warnf("Bad signature from %s: %v", c.ClientIP(), err)
+		sendErrorResponse("bad signature", http.StatusBadRequest, c)
+		return
+	}
+
+	if !ticketFound {
 		log.Warnf("Invalid ticket from %s", c.ClientIP())
 		sendErrorResponse("invalid ticket", http.StatusBadRequest, c)
-		return
-	}
-
-	// verify message
-	message := fmt.Sprintf("vsp v3 ticketstatus %d %s", ticketStatusRequest.Timestamp, ticketHashStr)
-	err = dcrutil.VerifyMessage(ticket.CommitmentAddress, signature, message, cfg.NetParams)
-	if err != nil {
-		log.Warnf("Invalid signature from %s: %v", c.ClientIP(), err)
-		sendErrorResponse("invalid signature", http.StatusBadRequest, c)
 		return
 	}
 

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -13,7 +13,6 @@ type feeResponse struct {
 type FeeAddressRequest struct {
 	Timestamp  int64  `json:"timestamp" binding:"required"`
 	TicketHash string `json:"tickethash" binding:"required"`
-	Signature  string `json:"signature" binding:"required"`
 }
 
 type feeAddressResponse struct {
@@ -41,7 +40,6 @@ type payFeeResponse struct {
 type SetVoteChoicesRequest struct {
 	Timestamp   int64             `json:"timestamp" binding:"required"`
 	TicketHash  string            `json:"tickethash" binding:"required"`
-	Signature   string            `json:"commitmentsignature" binding:"required"`
 	VoteChoices map[string]string `json:"votechoices" binding:"required"`
 }
 
@@ -54,7 +52,6 @@ type setVoteChoicesResponse struct {
 type TicketStatusRequest struct {
 	Timestamp  int64  `json:"timestamp" binding:"required"`
 	TicketHash string `json:"tickethash" binding:"required"`
-	Signature  string `json:"signature" binding:"required"`
 }
 
 type ticketStatusResponse struct {

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -150,8 +150,9 @@ func router(debugMode bool) *gin.Engine {
 	api := router.Group("/api")
 	{
 		api.GET("/fee", fee)
-		api.POST("/feeaddress", feeAddress)
 		api.GET("/pubkey", pubKey)
+		// The following 4 calls require valid VSP-Client-Signature headers.
+		api.POST("/feeaddress", feeAddress)
 		api.POST("/payfee", payFee)
 		api.POST("/setvotechoices", setVoteChoices)
 		api.GET("/ticketstatus", ticketStatus)
@@ -188,7 +189,7 @@ func sendJSONResponse(resp interface{}, c *gin.Context) {
 	}
 
 	sig := ed25519.Sign(cfg.SignKey, dec)
-	c.Writer.Header().Set("VSP-Signature", hex.EncodeToString(sig))
+	c.Writer.Header().Set("VSP-Server-Signature", hex.EncodeToString(sig))
 
 	c.AbortWithStatusJSON(http.StatusOK, resp)
 }


### PR DESCRIPTION
- Remove Signature from all requests, and instead expect a signature in HTTP header "VSP-Client-Signature".
- Remove CommitmentSignatures from the database.
- Use a bool flag to indicate when a ticket is missing from the database rather than an error.
- Introduce middleware to handle setting up RPC clients
- Use middleware to handle authentication
