### PR TITLE
Calculate fee from percentage.

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -18,9 +18,9 @@ type NotificationHandler struct {
 	dcrdClient    *rpc.DcrdRPC
 }
 
-// The number of confirmations required to consider a ticket purchase or a fee
-// transaction to be final.
 const (
+	// requiredConfs is the number of confirmations required to consider a
+	// ticket purchase or a fee transaction to be final.
 	requiredConfs = 6
 )
 

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ import (
 var (
 	defaultListen         = ":3000"
 	defaultLogLevel       = "debug"
-	defaultVSPFee         = 0.001
+	defaultVSPFee         = 0.05
 	defaultNetwork        = "testnet"
 	defaultHomeDir        = dcrutil.AppDataDir("dcrvsp", false)
 	defaultConfigFilename = "dcrvsp.conf"
@@ -35,7 +35,7 @@ type config struct {
 	LogLevel       string  `long:"loglevel" ini-name:"loglevel" description:"Logging level." choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"critical"`
 	Network        string  `long:"network" ini-name:"network" description:"Decred network to use." choice:"testnet" choice:"mainnet" choice:"simnet"`
 	FeeXPub        string  `long:"feexpub" ini-name:"feexpub" description:"Cold wallet xpub used for collecting fees."`
-	VSPFee         float64 `long:"vspfee" ini-name:"vspfee" description:"Fee charged for VSP use. Absolute value - eg. 0.01 = 0.01 DCR."`
+	VSPFee         float64 `long:"vspfee" ini-name:"vspfee" description:"Fee percentage charged for VSP use. eg. 0.01 (1%), 0.05 (5%)."`
 	HomeDir        string  `long:"homedir" ini-name:"homedir" no-ini:"true" description:"Path to application home directory. Used for storing VSP database and logs."`
 	ConfigFile     string  `long:"configfile" ini-name:"configfile" no-ini:"true" description:"Path to configuration file."`
 	DcrdHost       string  `long:"dcrdhost" ini-name:"dcrdhost" description:"The ip:port to establish a JSON-RPC connection with dcrd. Should be the same host where dcrvsp is running."`

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -19,7 +19,7 @@ func exampleTicket() Ticket {
 		CommitmentAddress: "Address",
 		FeeAddressIndex:   12345,
 		FeeAddress:        "FeeAddress",
-		VSPFee:            0.1,
+		FeeAmount:         0.1,
 		FeeExpiration:     4,
 		Confirmed:         false,
 		VoteChoices:       map[string]string{"AgendaID": "Choice"},
@@ -106,7 +106,7 @@ func testGetTicketByHash(t *testing.T) {
 		retrieved.CommitmentAddress != ticket.CommitmentAddress ||
 		retrieved.FeeAddressIndex != ticket.FeeAddressIndex ||
 		retrieved.FeeAddress != ticket.FeeAddress ||
-		retrieved.VSPFee != ticket.VSPFee ||
+		retrieved.FeeAmount != ticket.FeeAmount ||
 		retrieved.FeeExpiration != ticket.FeeExpiration ||
 		retrieved.Confirmed != ticket.Confirmed ||
 		!reflect.DeepEqual(retrieved.VoteChoices, ticket.VoteChoices) ||

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -17,7 +17,7 @@ type Ticket struct {
 	CommitmentAddress string  `json:"commitmentaddress"`
 	FeeAddressIndex   uint32  `json:"feeaddressindex"`
 	FeeAddress        string  `json:"feeaddress"`
-	VSPFee            float64 `json:"vspfee"`
+	FeeAmount         float64 `json:"feeamount"`
 	FeeExpiration     int64   `json:"feeexpiration"`
 
 	// Confirmed will be set when the ticket has 6+ confirmations.

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultFeeAddressExpiration = 24 * time.Hour
+	defaultFeeAddressExpiration = 1 * time.Hour
 )
 
 func main() {

--- a/rpc/dcrd.go
+++ b/rpc/dcrd.go
@@ -101,3 +101,19 @@ func (c *DcrdRPC) GetTicketCommitmentAddress(ticketHash string, netParams *chain
 func (c *DcrdRPC) NotifyBlocks() error {
 	return c.Call(c.ctx, "notifyblocks", nil)
 }
+
+func (c *DcrdRPC) GetBestBlockHeader() (*dcrdtypes.GetBlockHeaderVerboseResult, error) {
+	var bestBlock dcrdtypes.GetBestBlockResult
+	err := c.Call(c.ctx, "getbestblock", &bestBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	verbose := true
+	var blockHeader dcrdtypes.GetBlockHeaderVerboseResult
+	err = c.Call(c.ctx, "getblockheader", &blockHeader, bestBlock.Hash, verbose)
+	if err != nil {
+		return nil, err
+	}
+	return &blockHeader, nil
+}

--- a/rpc/dcrd.go
+++ b/rpc/dcrd.go
@@ -103,15 +103,15 @@ func (c *DcrdRPC) NotifyBlocks() error {
 }
 
 func (c *DcrdRPC) GetBestBlockHeader() (*dcrdtypes.GetBlockHeaderVerboseResult, error) {
-	var bestBlock dcrdtypes.GetBestBlockResult
-	err := c.Call(c.ctx, "getbestblock", &bestBlock)
+	var bestBlockHash string
+	err := c.Call(c.ctx, "getbestblockhash", &bestBlockHash)
 	if err != nil {
 		return nil, err
 	}
 
 	verbose := true
 	var blockHeader dcrdtypes.GetBlockHeaderVerboseResult
-	err = c.Call(c.ctx, "getblockheader", &blockHeader, bestBlock.Hash, verbose)
+	err = c.Call(c.ctx, "getblockheader", &blockHeader, bestBlockHash, verbose)
 	if err != nil {
 		return nil, err
 	}

--- a/webapi/status.go
+++ b/webapi/status.go
@@ -17,7 +17,7 @@ func pubKey(c *gin.Context) {
 // fee is the handler for "GET /fee".
 func fee(c *gin.Context) {
 	sendJSONResponse(feeResponse{
-		Timestamp: time.Now().Unix(),
-		Fee:       cfg.VSPFee,
+		Timestamp:     time.Now().Unix(),
+		FeePercentage: cfg.VSPFee,
 	}, c)
 }

--- a/webapi/templates/homepage.html
+++ b/webapi/templates/homepage.html
@@ -14,7 +14,7 @@
         <table>
             <tr><td>Total tickets:</td><td>{{ .TotalTickets }}</td></tr>
             <tr><td>FeePaid tickets:</td><td>{{ .FeePaidTickets }}</td></tr>
-            <tr><td>VSP Fee:</td><td>{{ .VSPFee }} DCR per ticket</td></tr>
+            <tr><td>VSP Fee:</td><td>{{ .VSPFee }}</td></tr>
             <tr><td>Network:</td><td>{{ .Network }}</td></tr>
         </table>
         <p>Last updated: {{.UpdateTime}}</p>

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -6,8 +6,8 @@ type pubKeyResponse struct {
 }
 
 type feeResponse struct {
-	Timestamp int64   `json:"timestamp" binding:"required"`
-	Fee       float64 `json:"fee" binding:"required"`
+	Timestamp     int64   `json:"timestamp" binding:"required"`
+	FeePercentage float64 `json:"feepercentage" binding:"required"`
 }
 
 type FeeAddressRequest struct {
@@ -18,7 +18,7 @@ type FeeAddressRequest struct {
 type feeAddressResponse struct {
 	Timestamp  int64             `json:"timestamp" binding:"required"`
 	FeeAddress string            `json:"feeaddress" binding:"required"`
-	Fee        float64           `json:"fee" binding:"required"`
+	FeeAmount  float64           `json:"feeamount" binding:"required"`
 	Expiration int64             `json:"expiration" binding:"required"`
 	Request    FeeAddressRequest `json:"request" binding:"required"`
 }

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -27,10 +27,12 @@ type Config struct {
 	FeeAddressExpiration time.Duration
 }
 
-// The number of confirmations required to consider a ticket purchase or a fee
-// transaction to be final.
 const (
+	// requiredConfs is the number of confirmations required to consider a
+	// ticket purchase or a fee transaction to be final.
 	requiredConfs = 6
+	// TODO: Make this configurable or get it from RPC.
+	relayFee = 0.0001
 )
 
 var homepageData *gin.H


### PR DESCRIPTION
- Reverted config to accept a fee percentage, not absolute value.
- The fee amount to be paid is now included in the `getfeeaddress` response. The current best block is used to calculate the fee percentage, and new blocks may be mined before the fee is paid, so the fee expiry period is shortened from 24 hours to 1 hour to mitigate this.
- Rename ticket db field to FeeAmount so it is more representative of the data it holds.
- API fields renamed to "FeePercentage" and "FeeAmount"
- Relay fee is still hard coded (#54)